### PR TITLE
Modify pytest.yml to streamline dependency installation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       # Install any additional dependencies not included in the pyproject.toml file
       - name: Install additional dependencies
         run: |
-          #conda install -y -c conda-forge -c bioconda mummer blast
+          conda install -y -c conda-forge -c bioconda mummer blast
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --retries 10 --timeout 180 --prefer-binary --progress-bar off --no-cache-dir '.[test]'
         shell: bash -l {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,11 +21,14 @@ jobs:
         with:
           auto-update-conda: true # Optional: update Conda to the latest version
           python-version: ${{ matrix.python-version }}
+          conda-remove-defaults: true
+          channels: conda-forge, bioconda
       # Install any additional dependencies not included in the pyproject.toml file
       - name: Install additional dependencies
         run: |
-          conda install -y -c conda-forge -c bioconda mummer blast
-          pip install '.[dev]'  # Install all dependencies, including test-specific ones
+          #conda install -y -c conda-forge -c bioconda mummer blast
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --retries 10 --timeout 180 --prefer-binary --progress-bar off --no-cache-dir '.[test]'
         shell: bash -l {0}
       - name: Verify pytest installation
         run: python -m pytest --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dev = [
     "ruff",
 ]
 
+test = [
+        "pytest-cov",
+        "pytest",
+]
+
 # Project URLs
 [project.urls]
 homepage = "https://github.com/adamtaranto/tSplit"

--- a/src/tsplit/parseAlign.py
+++ b/src/tsplit/parseAlign.py
@@ -393,7 +393,7 @@ def filterCoordsFileTIR(
     # x.qry_end - x.ref_end =
     # 5'end of right TIR - 3' end of left TIR = length of internal segment
     # TIR pair with largest internal segment (outermost TIRs) is first in list.
-    alignments = sorted(alignments, key=lambda x: (x.qry_end - x.ref_end), reverse=True)
+    alignments = sorted(alignments, key=lambda x: x.qry_end - x.ref_end, reverse=True)
 
     return alignments
 
@@ -724,9 +724,7 @@ def filterCoordsFileLTR(
 
     # Sort largest to smallest dist between end of ref (subject) and start of query (hit)
     # x.qry_start (3') - x.ref_end (5') = Length of internal segment
-    alignments = sorted(
-        alignments, key=lambda x: (x.qry_start - x.ref_end), reverse=True
-    )
+    alignments = sorted(alignments, key=lambda x: x.qry_start - x.ref_end, reverse=True)
 
     return alignments
 


### PR DESCRIPTION
Updated pytest workflow to remove conda install for mummer and blast, and adjusted pip install command for test dependencies.